### PR TITLE
Correct array management of objects

### DIFF
--- a/src/transForm.js
+++ b/src/transForm.js
@@ -1,4 +1,4 @@
-﻿(function (name, definition) {
+(function (name, definition) {
     if (typeof module != 'undefined')
         module.exports = definition();
     else if (typeof define == 'function' && typeof define.amd == 'object')
@@ -19,7 +19,7 @@
         skipFalsy: false,
         skipReadOnly: false,
         triggerChange: false,
-        useIdOnEmptyName: true,
+        useIdOnEmptyName: true
     };
 
     /* Serialize */
@@ -142,7 +142,13 @@
             } else {
                 // check if the next part is an index
                 var index = parts[i + 1];
-                if (!index || isType(index, 'number')) {
+                var a = !index;
+                var b = isType(index, 'number');
+                var c = typeof (Number(index)) === 'number';
+                var d = Number.isNaN(Number(index));
+                var e = !b && (c && !d);
+
+                if ( a || b || e) {
                     if (!isType(parent[part], 'array'))
                         parent[part] = [];
                     // if second last


### PR DESCRIPTION
Creates an array of objects instead of nested objects inside of a parent object.

Correct behaviour:
{"f": [{"id": 1},{"id": 2}]}

Instead of:
{"f": {{"id": 1},{"id": 2}}}

The reason is that the string "parentObject[0].innerObject" is split into the array ["parentObject","0","innerObject"] and your function isType(t, str) doesn't understand that the second string "0" is a number (and thus an array index).

If there is another way to achieve the same result without changing the code (and configuring something in the calling code) please let me know.

Thanks